### PR TITLE
Support isNullOverride in applyToDefaults

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ internals.schema = Joi.object({
 
     clearInvalid: Joi.boolean(),
     autoValue: Joi.any(),
-    passThrough: Joi.boolean()    
+    passThrough: Joi.boolean()
 });
 
 
@@ -54,7 +54,7 @@ exports.Definitions = internals.Definitions = function (options) {
 
     this.settings = Hoek.applyToDefaults(internals.defaults, options || {});
     Joi.assert(this.settings, internals.schema, 'Invalid state definition defaults');
-    
+
     this.cookies = {};
     this.names = [];
 };
@@ -65,7 +65,7 @@ internals.Definitions.prototype.add = function (name, options) {
     Hoek.assert(name && typeof name === 'string', 'Invalid name');
     Hoek.assert(!this.cookies[name], 'State already defined:', name);
 
-    var settings = Hoek.applyToDefaults(this.settings, options || {});
+    var settings = Hoek.applyToDefaults(this.settings, options || {}, true);
     Joi.assert(settings, internals.schema, 'Invalid state definition: ' + name);
 
     this.cookies[name] = settings;
@@ -124,7 +124,7 @@ internals.Definitions.prototype.parse = function (cookies, next) {
 
         return '';
     });
-    
+
     // Validate cookie header syntax
 
     if (verify !== '') {
@@ -351,7 +351,7 @@ internals.Definitions.prototype.format = function (cookies, callback) {
         // Apply definition to local configuration
 
         var base = self.cookies[cookie.name] || self.settings;
-        var definition = cookie.options ? Hoek.applyToDefaults(base, cookie.options) : base;
+        var definition = cookie.options ? Hoek.applyToDefaults(base, cookie.options, true) : base;
 
         // Validate name
 

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,19 @@ describe('Definitions', function () {
             expect(definitions.names).to.deep.equal(['test']);
             done();
         });
+
+        it('adds definition with null value', function (done) {
+
+            var definitions = new Statehood.Definitions({ path: '/' });
+
+            definitions.add('base');
+            expect(definitions.cookies.base.path).to.equal('/');
+
+            definitions.add('test', { path: null });
+            expect(definitions.cookies.test.path).to.equal(null);
+
+            done();
+        });
     });
 
     describe('parse()', function () {
@@ -768,7 +781,7 @@ describe('Definitions', function () {
 
         it('formats a header (with null ttl)', function (done) {
 
-            var definitions = new Statehood.Definitions();
+            var definitions = new Statehood.Definitions({ ttl: 3600 });
             definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { ttl: null, isSecure: true, isHttpOnly: true, path: '/', domain: 'example.com' } }, function (err, header) {
 
                 expect(err).to.not.exist();
@@ -1202,4 +1215,3 @@ describe('exclude()', function () {
         done();
     });
 });
-


### PR DESCRIPTION
https://github.com/hapijs/hapi-auth-cookie/issues/59 presented the need for for options with properties that were `null` to show up in the result of `Hoek.applyToDefaults`.  https://github.com/hapijs/hoek/pull/140 took care of that, but it requires a flag to be turned on.

This PR turns this flag on and adds/updates tests to ensure that the expected result is occurring.