### PR TITLE
allow empty names (where equals is not specified). Closes another edge case for #15

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,8 +80,8 @@ internals.empty = new internals.Definitions();
 
 // Header format
 
-//                      1: name                2: quoted  3: value
-internals.parseRx = /\s*([^=\s]*)\s*=\s*(?:(?:"([^\"]*)")|([^\;]*))(?:(?:;\s*)|$)/g;
+//                             1: name                 2: quoted  3: value   4: value on its own
+internals.parseRx = /\s*(?:(?:([^=;\s]*)\s*=\s*(?:(?:"([^\"]*)")|([^\;]*)))|([^=\;]+))(?:(?:;\s*)|$)/g;
 
 internals.validateRx = {
     nameRx: {
@@ -97,18 +97,17 @@ internals.validateRx = {
     pathRx: /^\/[^\x00-\x1F\;]*$/
 };
 
-//                      1: name         2: value
-internals.pairsRx = /\s*([^=\s]*)\s*=\s*([^\;]*)(?:(?:;\s*)|$)/g;
+//                             1: name          2: value  3: value on its own
+internals.pairsRx = /\s*(?:(?:([^=;\s]*)\s*=\s*([^\;]*))|([^=\;]+))(?:(?:;\s*)|$)/g;
 
 
 internals.Definitions.prototype.parse = function (cookies, next) {
 
     const state = {};
     const names = [];
-    const verify = cookies.replace(internals.parseRx, ($0, $1, $2, $3) => {
-
-        const name = $1;
-        const value = $2 || $3 || '';
+    const verify = cookies.replace(internals.parseRx, ($0, $1, $2, $3, $4) => {
+        const name = $1 || '';
+        const value = $2 || $3 || $4 || '';
 
         if (state[name]) {
             if (!Array.isArray(state[name])) {
@@ -542,10 +541,11 @@ internals.Definitions.prototype.passThrough = function (header, fallback) {
 exports.exclude = function (cookies, excludes) {
 
     let result = '';
-    const verify = cookies.replace(internals.pairsRx, ($0, $1, $2) => {
-
-        if (excludes.indexOf($1) === -1) {
-            result = result + (result ? ';' : '') + $1 + '=' + $2;
+    const verify = cookies.replace(internals.pairsRx, ($0, $1, $2, $3) => {
+        const name = $1 || '';
+        const value = $2 || $3;
+        if (excludes.indexOf(name) === -1) {
+            result = result + (result ? ';' : '') + name + '=' + value;
         }
 
         return '';

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,6 +106,7 @@ internals.Definitions.prototype.parse = function (cookies, next) {
     const state = {};
     const names = [];
     const verify = cookies.replace(internals.parseRx, ($0, $1, $2, $3, $4) => {
+
         const name = $1 || '';
         const value = $2 || $3 || $4 || '';
 
@@ -542,6 +543,7 @@ exports.exclude = function (cookies, excludes) {
 
     let result = '';
     const verify = cookies.replace(internals.pairsRx, ($0, $1, $2, $3) => {
+
         const name = $1 || '';
         const value = $2 || $3;
         if (excludes.indexOf(name) === -1) {

--- a/test/index.js
+++ b/test/index.js
@@ -91,10 +91,22 @@ describe('Definitions', () => {
             });
         });
 
-        it('parses cookie (loose)', (done) => {
+        it('parses cookie (loose - with empty name using equals)', (done) => {
 
             const definitions = new Statehood.Definitions({ strictHeader: false });
             definitions.parse('a="1; b="2"; c=3; d[1]=4;=1', (err, states, failed) => {
+
+                expect(err).to.not.exist();
+                expect(failed).to.have.length(0);
+                expect(states).to.deep.equal({ a: '"1', b: '2', c: '3', 'd[1]': '4', '': '1' });
+                done();
+            });
+        });
+
+        it('parses cookie (loose  - with empty name not using equals)', (done) => {
+
+            const definitions = new Statehood.Definitions({ strictHeader: false });
+            definitions.parse('a="1; b="2"; c=3; d[1]=4; 1', (err, states, failed) => {
 
                 expect(err).to.not.exist();
                 expect(failed).to.have.length(0);
@@ -1221,7 +1233,7 @@ describe('exclude()', () => {
         done();
     });
 
-    it('returns keys without excluded (empty name)', (done) => {
+    it('returns keys without excluded (empty name with equals)', (done) => {
 
         const header = '=4;b=5;c=6';
         const result = Statehood.exclude(header, ['']);
@@ -1229,11 +1241,11 @@ describe('exclude()', () => {
         done();
     });
 
-    it('returns error on invalid header', (done) => {
+    it('returns keys without excluded (empty name without equals)', (done) => {
 
-        const header = 'a';
-        const result = Statehood.exclude(header, ['b']);
-        expect(result.message).to.equal('Invalid cookie header');
+        const header = '4;b=5;c=6';
+        const result = Statehood.exclude(header, ['']);
+        expect(result).to.equal('b=5;c=6');
         done();
     });
 });


### PR DESCRIPTION
#### What's this PR do?
Adds another edge case for where cookies are nameless, and don't use equals to delimit. For example, in chrome setting a nameless cookie will result in the cookie simply being `value` rather than `=value`.
#### Where should the reviewer start?
`npm test`
#### What are the relevant tickets?
https://github.com/hapijs/statehood/commit/b4eeef87dcb6db1f4add3e201699046452c8b001#commitcomment-15846931