### PR TITLE
Validate cookie values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,12 +20,14 @@ const internals = {};
 internals.schema = Joi.object({
     strictHeader: Joi.boolean(),
     ignoreErrors: Joi.boolean(),
+
     isSecure: Joi.boolean(),
     isHttpOnly: Joi.boolean(),
     isSameSite: Joi.valid('Strict', 'Lax').allow(false),
     path: Joi.string().allow(null),
     domain: Joi.string().allow(null),
     ttl: Joi.number().allow(null),
+
     encoding: Joi.string().valid('base64json', 'base64', 'form', 'iron', 'none'),
     sign: Joi.object({
         password: [Joi.string(), Joi.binary(), Joi.object()],
@@ -45,12 +47,14 @@ internals.schema = Joi.object({
 internals.defaults = {
     strictHeader: true,                             // Require an RFC 6265 compliant header format
     ignoreErrors: false,
+
     isSecure: true,
     isHttpOnly: true,
     isSameSite: 'Strict',
     path: null,
     domain: null,
     ttl: null,                                      // MSecs, 0 means remove
+
     encoding: 'none'                                // options: 'base64json', 'base64', 'form', 'iron', 'none'
 };
 
@@ -71,7 +75,7 @@ internals.Definitions.prototype.add = function (name, options) {
     Hoek.assert(!this.cookies[name], 'State already defined:', name);
 
     const settings = Hoek.applyToDefaults(this.settings, options || {}, true);
-    Joi.assert(settings, internals.schema, 'Invalid state definition: ' + name);
+    Joi.assert(settings, internals.schema.append({ validate: Joi.object().schema() }), 'Invalid state definition: ' + name);
 
     this.cookies[name] = settings;
     this.names.push(name);
@@ -217,6 +221,27 @@ internals.Definitions.prototype.parse = async function (cookies) {
         }
 
         parsed[name] = arrayResult;
+    }
+
+    // validate parsed cookie values
+
+    for (const name in this.cookies) {
+        const definition = this.cookies[name];
+        if (!definition.validate) {
+            continue;
+        }
+
+        try {
+            const value = await Joi.validate(parsed[name], definition.validate);
+            if (value !== undefined) {
+                parsed[name] = value;
+            }
+        }
+        catch (err) {
+            Bounce.rethrow(err, 'system');
+            record(err, name, state[name], definition);
+            delete parsed[name];
+        }
     }
 
     if (errored.length) {


### PR DESCRIPTION
Closes #50.

Still pondering what to do about `validate` in defaults - not sure there's a use case for it, and at the moment it would crash with "Maximum call stack exceeded" due to how `Hoek.applyToDefaults` works. Options: leave as is; support it properly; explicitly not support it.

Will add docs and some tests on hapi side once I make up my mind on the above.