### PR TITLE
Parse cookie pairs without a regex

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,9 +57,6 @@ internals.defaults = {
 
 // Header format
 
-//                      1: name                2: quoted  3: value
-internals.parseRx = /\s*([^=\s]*)\s*=\s*(?:(?:"([^\"]*)")|([^\;]*))(?:(?:;\s*)|$)/g;
-
 internals.validateRx = {
     nameRx: {
         strict: /^[^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+$/,
@@ -105,10 +102,7 @@ exports.Definitions = class {
 
         const state = {};
         const names = [];
-        const verify = cookies.replace(internals.parseRx, ($0, $1, $2, $3) => {
-
-            const name = $1;
-            const value = $2 || $3 || '';
+        const verify = internals.parsePairs(cookies, (name, value) => {
 
             if (name === '__proto__') {
                 throw Boom.badRequest('Invalid cookie header');
@@ -125,15 +119,13 @@ exports.Definitions = class {
                 state[name] = value;
                 names.push(name);
             }
-
-            return '';
         });
 
         // Validate cookie header syntax
 
         const failed = [];                                                // All errors
 
-        if (verify !== '') {
+        if (verify !== null) {
             if (!this.settings.ignoreErrors) {
                 throw Boom.badRequest('Invalid cookie header');
             }
@@ -348,6 +340,33 @@ exports.Definitions = class {
     }
 };
 
+
+internals.parsePairs = function (cookies, eachPairFn) {
+
+    let index = 0;
+
+    while (index < cookies.length) {
+
+        const eqIndex = cookies.indexOf('=', index);
+
+        if (eqIndex === -1) {
+            return cookies.slice(index); // E.g. 'a=1;bcd' -> 'bcd'
+        }
+
+        const semiIndex = cookies.indexOf(';', eqIndex);
+        const endOfValueIndex = semiIndex !== -1 ? semiIndex : cookies.length;
+
+        const key = cookies.slice(index, eqIndex).trim();
+        const value = cookies.slice(eqIndex + 1, endOfValueIndex).trim();
+        const unquotedValue = (value.startsWith('"') && value.endsWith('"')) ? value.slice(1, -1) : value;
+
+        eachPairFn(key, unquotedValue);
+
+        index = endOfValueIndex + 1;
+    }
+
+    return null;
+};
 
 internals.validate = function (name, state) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -350,18 +350,19 @@ internals.parsePairs = function (cookies, eachPairFn) {
         const eqIndex = cookies.indexOf('=', index);
 
         if (eqIndex === -1) {
-            return cookies.slice(index); // E.g. 'a=1;bcd' -> 'bcd'
+            return cookies.slice(index);    // E.g. 'a=1;xyz' -> 'xyz'
         }
 
         const semiIndex = cookies.indexOf(';', eqIndex);
         const endOfValueIndex = semiIndex !== -1 ? semiIndex : cookies.length;
 
-        const key = cookies.slice(index, eqIndex).trim();
+        const name = cookies.slice(index, eqIndex).trim();
         const value = cookies.slice(eqIndex + 1, endOfValueIndex).trim();
-        const unquotedValue = (value.startsWith('"') && value.endsWith('"')) ? value.slice(1, -1) : value;
+        const unquotedValue = (value.startsWith('"') && value.endsWith('"') && value !== '"') ?
+            value.slice(1, -1) :    // E.g. '"abc"' -> 'abc'
+            value;
 
-        eachPairFn(key, unquotedValue);
-
+        eachPairFn(name, unquotedValue);
         index = endOfValueIndex + 1;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -83,6 +83,14 @@ describe('Definitions', () => {
             expect(states).to.equal({ a: '"1', b: '2', c: '3', 'd[1]': '4', '': '1' });
         });
 
+        it('parses cookie (none)', async () => {
+
+            const definitions = new Statehood.Definitions();
+            const { states, failed } = await definitions.parse('');
+            expect(failed).to.have.length(0);
+            expect(states).to.equal({});
+        });
+
         it('parses cookie (empty)', async () => {
 
             const definitions = new Statehood.Definitions();
@@ -486,6 +494,29 @@ describe('Definitions', () => {
                         ignoreErrors: true
                     },
                     reason: 'Header contains unexpected syntax: ;'
+                }
+            ]);
+        });
+
+        it('fails parsing cookie (missing values, ignoring errors)', async () => {
+
+            const definitions = new Statehood.Definitions({ ignoreErrors: true });
+            const { states, failed } = await definitions.parse('a=1; b=2; c=3;qrs;tuv');
+            expect(states).to.equal({ a: '1', b: '2', c: '3' });
+            expect(failed).to.equal([
+                {
+                    settings: {
+                        isSecure: true,
+                        isHttpOnly: true,
+                        isSameSite: 'Strict',
+                        path: null,
+                        domain: null,
+                        ttl: null,
+                        encoding: 'none',
+                        strictHeader: true,
+                        ignoreErrors: true
+                    },
+                    reason: 'Header contains unexpected syntax: qrs;tuv'
                 }
             ]);
         });

--- a/test/index.js
+++ b/test/index.js
@@ -372,6 +372,7 @@ describe('Definitions', () => {
 
             const definitions = new Statehood.Definitions({ ignoreErrors: true });
             const { failed, states } = await definitions.parse('a="1; b="2"; c=3');
+            expect(states).to.equal({ b: '2', c: '3' });
             expect(failed).to.equal([
                 {
                     name: 'a',
@@ -390,14 +391,54 @@ describe('Definitions', () => {
                     reason: 'Invalid cookie value'
                 }
             ]);
+        });
 
-            expect(states).to.equal({ b: '2', c: '3' });
+        it('ignores failed parsing cookie (mismatching, paired quotes)', async () => {
+
+            const definitions = new Statehood.Definitions({ ignoreErrors: true });
+            const { failed, states } = await definitions.parse('a="; b=2; "; c=3');
+            expect(states).to.equal({ b: '2' });
+            expect(failed).to.equal([
+                {
+                    name: 'a',
+                    value: '"',
+                    settings: {
+                        strictHeader: true,
+                        ignoreErrors: true,
+                        isSecure: true,
+                        isHttpOnly: true,
+                        isSameSite: 'Strict',
+                        path: null,
+                        domain: null,
+                        ttl: null,
+                        encoding: 'none'
+                    },
+                    reason: 'Invalid cookie value'
+                },
+                {
+                    name: '"; c',
+                    value: '3',
+                    settings: {
+                        strictHeader: true,
+                        ignoreErrors: true,
+                        isSecure: true,
+                        isHttpOnly: true,
+                        isSameSite: 'Strict',
+                        path: null,
+                        domain: null,
+                        ttl: null,
+                        encoding: 'none'
+                    },
+                    reason: 'Invalid cookie name'
+                }
+            ]);
         });
 
         it('ignores failed parsing cookie (lone quote)', async () => {
 
             const definitions = new Statehood.Definitions({ ignoreErrors: true });
             const { failed, states } = await definitions.parse('a="; b="2"; c=3');
+            expect(states).to.equal({ b: '2', c: '3' });
             expect(failed).to.equal([
                 {
                     name: 'a',
@@ -416,8 +457,6 @@ describe('Definitions', () => {
                     reason: 'Invalid cookie value'
                 }
             ]);
-
-            expect(states).to.equal({ b: '2', c: '3' });
         });
 
         it('ignores failed parsing cookie (cookie settings)', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -371,7 +371,7 @@ describe('Definitions', () => {
         it('ignores failed parsing cookie (mismatching quotes)', async () => {
 
             const definitions = new Statehood.Definitions({ ignoreErrors: true });
-            const { failed } = await definitions.parse('a="1; b="2"; c=3');
+            const { failed, states } = await definitions.parse('a="1; b="2"; c=3');
             expect(failed).to.equal([
                 {
                     name: 'a',
@@ -390,6 +390,34 @@ describe('Definitions', () => {
                     reason: 'Invalid cookie value'
                 }
             ]);
+
+            expect(states).to.equal({ b: '2', c: '3' });
+        });
+
+        it('ignores failed parsing cookie (lone quote)', async () => {
+
+            const definitions = new Statehood.Definitions({ ignoreErrors: true });
+            const { failed, states } = await definitions.parse('a="; b="2"; c=3');
+            expect(failed).to.equal([
+                {
+                    name: 'a',
+                    value: '"',
+                    settings: {
+                        isSecure: true,
+                        isHttpOnly: true,
+                        isSameSite: 'Strict',
+                        path: null,
+                        domain: null,
+                        ttl: null,
+                        encoding: 'none',
+                        strictHeader: true,
+                        ignoreErrors: true
+                    },
+                    reason: 'Invalid cookie value'
+                }
+            ]);
+
+            expect(states).to.equal({ b: '2', c: '3' });
         });
 
         it('ignores failed parsing cookie (cookie settings)', async () => {


### PR DESCRIPTION
Using a simple parser rather than a regex is a more direct, durable, and performant solution to collecting cookie name-value pairs.  I think that writing this logic out also makes it a bit clearer how we treat bad/invalid cookies.  In order to confirm that the behavior remains identical to the regex-based parser, I added tests for a couple additional edge-cases. 