### PR TITLE
Support node v18, drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,7 @@ exports.Definitions = class {
 
     constructor(options) {
 
-        this.settings = Hoek.applyToDefaults(internals.defaults, options || {});
+        this.settings = Hoek.applyToDefaults(internals.defaults, options ?? {});
         Validate.assert(this.settings, internals.schema, 'Invalid state definition defaults');
 
         this.cookies = {};
@@ -91,7 +91,7 @@ exports.Definitions = class {
         Hoek.assert(name && typeof name === 'string', 'Invalid name');
         Hoek.assert(!this.cookies[name], 'State already defined:', name);
 
-        const settings = Hoek.applyToDefaults(this.settings, options || {}, { nullOverride: true });
+        const settings = Hoek.applyToDefaults(this.settings, options ?? {}, { nullOverride: true });
         Validate.assert(settings, internals.schema, 'Invalid state definition: ' + name);
 
         this.cookies[name] = settings;
@@ -156,7 +156,7 @@ exports.Definitions = class {
         const parsed = {};
         for (const name of names) {
             const value = state[name];
-            const definition = this.cookies[name] || this.settings;
+            const definition = this.cookies[name] ?? this.settings;
 
             // Validate cookie
 
@@ -237,7 +237,7 @@ exports.Definitions = class {
 
             // Apply definition to local configuration
 
-            const base = this.cookies[cookie.name] || this.settings;
+            const base = this.cookies[cookie.name] ?? this.settings;
             let definition = cookie.options ? Hoek.applyToDefaults(base, cookie.options, { nullOverride: true }) : base;
 
             // Contextualize definition
@@ -412,7 +412,7 @@ internals.unsign = async function (name, value, definition) {
     const hmacSalt = sigParts[0];
     const hmac = sigParts[1];
 
-    const macOptions = Hoek.clone(definition.sign.integrity || Iron.defaults.integrity);
+    const macOptions = Hoek.clone(definition.sign.integrity ?? Iron.defaults.integrity);
     macOptions.salt = hmacSalt;
     const mac = await Iron.hmacWithPassword(definition.sign.password, macOptions, [internals.macPrefix, name, unsigned].join('\n'));
     if (!Cryptiles.fixedTimeComparison(mac.digest, hmac)) {
@@ -436,7 +436,7 @@ internals.decode = async function (value, definition) {
     // Encodings: 'base64json', 'base64', 'form', 'iron', 'none'
 
     if (definition.encoding === 'iron') {
-        return await Iron.unseal(value, definition.password, definition.iron || Iron.defaults);
+        return await Iron.unseal(value, definition.password, definition.iron ?? Iron.defaults);
     }
 
     if (definition.encoding === 'base64json') {
@@ -485,7 +485,7 @@ internals.encode = function (value, options) {
     }
 
     if (options.encoding === 'iron') {
-        return Iron.seal(value, options.password, options.iron || Iron.defaults);
+        return Iron.seal(value, options.password, options.iron ?? Iron.defaults);
     }
 
     if (options.encoding === 'base64') {
@@ -511,7 +511,7 @@ internals.sign = async function (name, value, options) {
         return value;
     }
 
-    const mac = await Iron.hmacWithPassword(options.password, options.integrity || Iron.defaults.integrity, [internals.macPrefix, name, value].join('\n'));
+    const mac = await Iron.hmacWithPassword(options.password, options.integrity ?? Iron.defaults.integrity, [internals.macPrefix, name, value].join('\n'));
     const signed = value + '.' + mac.salt + '*' + mac.digest;
     return signed;
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@hapi/bourne": "^3.0.0",
     "@hapi/cryptiles": "^6.0.0",
     "@hapi/hoek": "^10.0.0",
-    "@hapi/iron": "^6.0.0",
+    "@hapi/iron": "^7.0.0",
     "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,18 +19,18 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/bounce": "2.x.x",
-    "@hapi/bourne": "2.x.x",
-    "@hapi/cryptiles": "5.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/iron": "6.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/bounce": "^3.0.0",
+    "@hapi/bourne": "^3.0.0",
+    "@hapi/cryptiles": "^6.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/iron": "^6.0.0",
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Statehood;
+
+    before(async () => {
+
+        Statehood = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Statehood)).to.equal([
+            'Definitions',
+            'default',
+            'exclude',
+            'prepareValue'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules.

If this looks good, this will go out as statehood v8.