### PR TITLE
Add support to cookie partition

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -45,6 +45,11 @@ export interface StateOptions<HapiRequest> {
   isSameSite?: SameSitePolicy | undefined;
 
   /**
+   * Sets the `Partitioned` flag. For more information, please access https://developers.google.com/privacy-sandbox/3pcd/chips
+   */
+  isPartitioned?: boolean | undefined;
+
+  /**
    * The path scope.
    *
    * @default null (no path)

--- a/lib/index.js
+++ b/lib/index.js
@@ -295,7 +295,7 @@ exports.Definitions = class {
                 segment = `${segment}; SameSite=${definition.isSameSite}`;
             }
 
-            if (definition.isPartitioned) {
+            if (definition.isPartitioned && definition.isSecure && definition.isSameSite === 'None') {
                 segment = `${segment}; Partitioned`;
             }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -295,7 +295,15 @@ exports.Definitions = class {
                 segment = `${segment}; SameSite=${definition.isSameSite}`;
             }
 
-            if (definition.isPartitioned && definition.isSecure && definition.isSameSite === 'None') {
+            if (definition.isPartitioned) {
+                if (!definition.isSecure) {
+                    throw Boom.badImplementation('Partitioned cookies must be secure');
+                }
+
+                if (definition.isSameSite !== 'None') {
+                    throw Boom.badImplementation('Partitioned cookies must have SameSite=None');
+                }
+
                 segment = `${segment}; Partitioned`;
             }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ internals.schema = Validate.object({
     ignoreErrors: Validate.boolean(),
     isSecure: Validate.boolean(),
     isHttpOnly: Validate.boolean(),
+    isPartitioned: Validate.boolean(),
     isSameSite: Validate.valid('Strict', 'Lax', 'None', false),
     path: Validate.string().allow(null),
     domain: Validate.string().allow(null),
@@ -47,6 +48,7 @@ internals.defaults = {
     ignoreErrors: false,
     isSecure: true,
     isHttpOnly: true,
+    isPartitioned: false,
     isSameSite: 'Strict',
     path: null,
     domain: null,
@@ -291,6 +293,10 @@ exports.Definitions = class {
 
             if (definition.isSameSite) {
                 segment = `${segment}; SameSite=${definition.isSameSite}`;
+            }
+
+            if (definition.isPartitioned) {
+                segment = `${segment}; Partitioned`;
             }
 
             if (definition.domain) {

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,7 @@ describe('Definitions', () => {
                 isSecure: true,
                 isHttpOnly: true,
                 isSameSite: 'Strict',
+                isPartitioned: false,
                 path: null,
                 domain: null,
                 ttl: null,
@@ -354,6 +355,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -381,6 +383,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -408,6 +411,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -424,6 +428,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -447,6 +452,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -478,6 +484,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -502,6 +509,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -518,6 +526,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -553,6 +562,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -576,6 +586,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -603,6 +614,7 @@ describe('Definitions', () => {
                         isSecure: true,
                         isHttpOnly: true,
                         isSameSite: 'Strict',
+                        isPartitioned: false,
                         path: null,
                         domain: null,
                         ttl: null,
@@ -1034,6 +1046,14 @@ describe('Definitions', () => {
             const definitions = new Statehood.Definitions();
             await expect(definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isHttpOnly: false, path: 'd', domain: 'example.com' } })).to.reject('Invalid cookie path: d');
         });
+
+        it('formats a header with cookie partitioned', async () => {
+
+            const definitions = new Statehood.Definitions();
+            const header = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: true, isHttpOnly: true, isSameSite: 'None' } });
+            expect(header[0]).to.equal('sid=fihfieuhr9384hf; Secure; HttpOnly; SameSite=None; Partitioned');
+        });
+
     });
 
     describe('passThrough()', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -1059,22 +1059,22 @@ describe('Definitions', () => {
             it('throws error if partitioned option if not secure', async () => {
 
                 const definitions = new Statehood.Definitions();
-                const result = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: false, isHttpOnly: true, isSameSite: 'None' } });
-                expect(result.message).to.equal('Partitioned cookies must be secure');
+                const err = await expect(definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: false, isHttpOnly: true, isSameSite: 'None' } })).to.reject();
+                expect(err.message).to.equal('Partitioned cookies must be secure');
             });
 
             it('throws error if partitioned option if not SameSite=None', async () => {
 
                 const definitions = new Statehood.Definitions();
-                const result = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: true, isHttpOnly: true, isSameSite: 'Lax' } });
-                expect(result.message).to.equal('Partitioned cookies must have SameSite=None');
+                const err = await expect(definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: true, isHttpOnly: true, isSameSite: 'Lax' } })).to.reject();
+                expect(err.message).to.equal('Partitioned cookies must have SameSite=None');
             });
 
             it('throws error if partitioned option if not secure and not SameSite=None', async () => {
 
                 const definitions = new Statehood.Definitions();
-                const result = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: false, isHttpOnly: true, isSameSite: 'Lax' } });
-                expect(result.message).to.equal('Partitioned cookies must be secure');
+                const err = await expect(definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: false, isHttpOnly: true, isSameSite: 'Lax' } })).to.reject();
+                expect(err.message).to.equal('Partitioned cookies must be secure');
             });
         });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1056,18 +1056,25 @@ describe('Definitions', () => {
                 expect(header[0]).to.equal('sid=fihfieuhr9384hf; Secure; HttpOnly; SameSite=None; Partitioned');
             });
 
-            it('ignores partitioned option if not secure', async () => {
+            it('throws error if partitioned option if not secure', async () => {
 
                 const definitions = new Statehood.Definitions();
-                const header = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: false, isHttpOnly: true, isSameSite: 'None' } });
-                expect(header[0]).to.equal('sid=fihfieuhr9384hf; HttpOnly; SameSite=None');
+                const result = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: false, isHttpOnly: true, isSameSite: 'None' } });
+                expect(result.message).to.equal('Partitioned cookies must be secure');
             });
 
-            it('ignores partitioned option if not SameSite=None', async () => {
+            it('throws error if partitioned option if not SameSite=None', async () => {
 
                 const definitions = new Statehood.Definitions();
-                const header = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: true, isHttpOnly: true, isSameSite: 'Lax' } });
-                expect(header[0]).to.equal('sid=fihfieuhr9384hf; Secure; HttpOnly; SameSite=Lax');
+                const result = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: true, isHttpOnly: true, isSameSite: 'Lax' } });
+                expect(result.message).to.equal('Partitioned cookies must have SameSite=None');
+            });
+
+            it('throws error if partitioned option if not secure and not SameSite=None', async () => {
+
+                const definitions = new Statehood.Definitions();
+                const result = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: false, isHttpOnly: true, isSameSite: 'Lax' } });
+                expect(result.message).to.equal('Partitioned cookies must be secure');
             });
         });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1047,11 +1047,28 @@ describe('Definitions', () => {
             await expect(definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isHttpOnly: false, path: 'd', domain: 'example.com' } })).to.reject('Invalid cookie path: d');
         });
 
-        it('formats a header with cookie partitioned', async () => {
+        describe('with partitioned cookies', () => {
 
-            const definitions = new Statehood.Definitions();
-            const header = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: true, isHttpOnly: true, isSameSite: 'None' } });
-            expect(header[0]).to.equal('sid=fihfieuhr9384hf; Secure; HttpOnly; SameSite=None; Partitioned');
+            it('formats a header with cookie partitioned', async () => {
+
+                const definitions = new Statehood.Definitions();
+                const header = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: true, isHttpOnly: true, isSameSite: 'None' } });
+                expect(header[0]).to.equal('sid=fihfieuhr9384hf; Secure; HttpOnly; SameSite=None; Partitioned');
+            });
+
+            it('ignores partitioned option if not secure', async () => {
+
+                const definitions = new Statehood.Definitions();
+                const header = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: false, isHttpOnly: true, isSameSite: 'None' } });
+                expect(header[0]).to.equal('sid=fihfieuhr9384hf; HttpOnly; SameSite=None');
+            });
+
+            it('ignores partitioned option if not SameSite=None', async () => {
+
+                const definitions = new Statehood.Definitions();
+                const header = await definitions.format({ name: 'sid', value: 'fihfieuhr9384hf', options: { isPartitioned: true, isSecure: true, isHttpOnly: true, isSameSite: 'Lax' } });
+                expect(header[0]).to.equal('sid=fihfieuhr9384hf; Secure; HttpOnly; SameSite=Lax');
+            });
         });
 
     });


### PR DESCRIPTION
## Why is this PR necessary?

To support Chrome's CHIPS initiative
https://developers.google.com/privacy-sandbox/3pcd/chips

## Tests

```
statehood feature/cookie-partition % npm run test

> @hapi/statehood@8.1.1 test
> lab -a @hapi/code -t 100 -L



  ..................................................
  ..................................................
  ..........

110 tests complete
Test duration: 48 ms
Assertions count: 162 (verbosity: 1.47)
Leaks: No issues
Coverage: 100.00%
Lint: No issues
```